### PR TITLE
Correcting --enable-avresample Invalid argument.

### DIFF
--- a/streaming_setup.py
+++ b/streaming_setup.py
@@ -74,7 +74,6 @@ all_ffmpeg_config = minimal_ffmpeg_config + [
     ("--enable-libopenjpeg", "libopenjpeg-dev libopenjp2-7-dev"),  # aarch64 64 issues
     ("--enable-librtmp", "librtmp-dev"),
     ("--enable-libass", "libass-dev"),
-    ("--enable-avresample", "libavresample-dev"),
     ("--enable-fontconfig", "libfontconfig1-dev"),
     ("--enable-chromaprint", "libchromaprint-dev"),
     ("--enable-frei0r", "frei0r-plugins-dev"),


### PR DESCRIPTION
media-video/ffmpeg - libavresample is deprecated since 2017.
Removed --enable-avresample option line.